### PR TITLE
Fixed Broken Links in Q8 and Q20

### DIFF
--- a/src/lab/faq.html
+++ b/src/lab/faq.html
@@ -137,7 +137,7 @@ In some of the labs, the user will first have to register prior to conducting th
 <p class="text-h3-darkblue-bold">Q8. What are the software requirements for Virtual Labs?</p>
 <p>Download Links for all the software required to use the labs are provided on
   each lab’s homepage (wherever required). Please click
-  on <a href="http://vlabs.ac.in/pre-requisites.html"> pre-requisites </a> link
+  on <a href="https://github.com/vlead/2018-outreach-remote-internship/blob/master/src/document-iiith.org#prerequisites"> pre-requisites </a> link
   to know the information about how to download, install and use the software.</p>	 
 <p class="text-h3-darkblue-bold">Q9. What are the system configuration needed to run Workshops ? </p>
 <p>System configuration required for running Virtual Labs:<br> 1) Browser: Firefox,
@@ -173,7 +173,7 @@ Chrome <br> 2) Plugins: Flash, Java 1.6 version, and IcedTea<br> 3) JavaScript s
 <p class="text-h3-darkblue-bold">Q20. How does one can contribute to Virtual-Labs?</p>
 <p> vlabs-dev is the main portal for Virtual Labs Development. Please visit
   the contributing section
-  of <a href="http://vlabs-dev.vlabs.ac.in/community/contributing.html"
+  of <a href="https://github.com/vlead/vlabs-dev-pages/blob/master/src/community/contributing.org"
   target="_blank">VLABS DEV</a> page.
 							
 							</div>


### PR DESCRIPTION
Removed the links to non-existing pages and re-directed to their Github counterparts instead.